### PR TITLE
Remove `server.js` from client-side caching

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -10,7 +10,6 @@ const FILES = [
   './css/modules/main.css',
 
   './script.js',
-  './server.js',
   './service-worker.js',
   './js/src/assets.js',
   './js/modules/create-timer.js',


### PR DESCRIPTION
The server implementation doesn't need to be cached client side